### PR TITLE
Switch from wget to curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ SRC_FILE = $(notdir $(URL))
 
 UNTRUSTED_SUFF := .UNTRUSTED
 
-FETCH_CMD := wget --no-use-server-timestamps -q -O
+ifeq ($(FETCH_CMD),)
+$(error "You can not run this Makefile without having FETCH_CMD defined")
+endif
 
 SHELL := /bin/bash
 %: %.sha256


### PR DESCRIPTION
curl has a better security track record than wget, and on Fedora uses a
better TLS library (OpenSSL instead of GnuTLS).  This change also adds
REPO_PROXY support.